### PR TITLE
Update Readme to include "About" info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # Commander Spellbook Website
 
+## About Commander's Spellbook
+
+The Commander Spellbook project is a search engine for Commander/EDH combos and to make them easily available across all modern digital platforms. 
+This community driven project is used to power [EDHREC's Combo Feature](https://edhrec.com/combos)
+
+The database and the source code for the website are [completely free and open source under the MIT license](https://opensource.org/licenses/MIT).
+We encourage you to copy this data so it lives on!
+
+[Combo Database Backend on Google Sheets](https://docs.google.com/spreadsheets/d/1JJo8MzkpuhfvsaKVFVlOoNymscCt-Aw-1sob2IhpwXY/)
+
+**Sincerely, the Community Admins:**
+
+[Lapper](https://twitter.com/lappermedic)
+[Goldshot20](https://www.moxfield.com/users/goldshot20)
+[AppleSaws](https://www.moxfield.com/users/AppleSaws)
+[Jaelyn Rosenquist](https://twitter.com/rosequartz_26)
+[Senior Edificer (Emeritus)](https://www.moxfield.com/users/SeniorEdificer)
+
 ## Installation Requirements
 
 Install [Node v14](https://nodejs.org/). This will also install the `npm` command line tool.


### PR DESCRIPTION
Updated Readme Page to include information from the published "About" page of the website, including:

- Link to Google Sheets backend
- links to EDHREC Combo Page and MIT License
- Community Admins and profile links